### PR TITLE
Decouple bell sounds with bell visibility.

### DIFF
--- a/src/collar/oc_bell.lsl
+++ b/src/collar/oc_bell.lsl
@@ -429,7 +429,6 @@ state active
 
     control( key kID, integer nHeld, integer nChange ) {
         if (!g_iBellOn) return;
-        if(!g_iBellShow)return;
         //the user is pressing a movement key
         if ((nChange & (CONTROL_LEFT|CONTROL_RIGHT|CONTROL_DOWN|CONTROL_UP|CONTROL_FWD|CONTROL_BACK)) && llGetTime()>g_fNextRing)
             llPlaySound(g_kCurrentBellSound,g_fVolume);


### PR DESCRIPTION
"Bell is ringing and hidden." is currently a lie because of this. Also they're separate options and should operate separately.